### PR TITLE
Fix OAuth API base URL and dev proxy

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,11 @@
 import axios from "axios";
 
+// Allow overriding the API base URL via environment variable
+// but default to the local backend when undefined
+const baseURL = import.meta.env.VITE_API_BASE_URL || "/api";
+
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL,
   withCredentials: true,               // ⇐ sends the refresh cookie
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    proxy: {
+      // During development forward API calls to the backend
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- fix axios base URL to default to `/api`
- proxy API calls to the backend in Vite config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68600bce8a64832a82e00f426eb0e855